### PR TITLE
Add conservative timeout for requests.

### DIFF
--- a/xylem/connection.py
+++ b/xylem/connection.py
@@ -13,6 +13,8 @@ from xylem import __version__
 ROOT = 'https://rhizome.carbonculture.net'
 API_PREFIX = 'api/v1'
 
+DEFAULT_TIMEOUT = 60 # seconds
+
 log = logging.getLogger(__name__)
 
 
@@ -44,7 +46,7 @@ class Connection(object):
         self._discover(self._test_connection())
 
     def _request(self, endpoint=None, method=None, params=None, data=None,
-                 extra_headers=None):
+                 extra_headers=None, timeout=DEFAULT_TIMEOUT):
         """Generic request, default to GET."""
         method = method or 'get'
         headers = extra_headers or {}
@@ -63,6 +65,7 @@ class Connection(object):
             params=params,
             data=data,
             headers=headers,
+            timeout=timeout,
         )
         return r
 


### PR DESCRIPTION
Re: https://www.pivotaltracker.com/story/show/127343913

I found an instance here a collector for UCL had basically hung waiting on a response from rhizome, for the best part of a day. The relatively conservative timeout here means that if something odd does happen with a request, we'll crash, and upstart will restart the collector.
